### PR TITLE
Allow building against hashable-1.3.

### DIFF
--- a/tree-diff.cabal
+++ b/tree-diff.cabal
@@ -76,7 +76,7 @@ library
     bytestring           >=0.10.4.0 && <0.11,
     containers           >=0.5.5.1  && <0.7,
     generics-sop         >=0.3.1.0  && <0.5,
-    hashable             >=1.2.6.1  && <1.3,
+    hashable             >=1.2.6.1  && <1.4,
     MemoTrie             >=0.6.8    && <0.7,
     parsec               >=3.1.11   && <3.2,
     parsers              >=0.12.7   && <0.13,


### PR DESCRIPTION
`Hashable` instances for `Float` and `Double` now behave consistently with the corresponding `Eq` instances, but that shouldn't affect `tree-diff`.